### PR TITLE
perf: Skip unnecessary intermediate-block queries when calculating by mean

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,8 +9,7 @@ Usage:
 go run main.go -date "Aug 21, 2023 1:23PM PDT" -rpc https://main.rpc.agoric.net:443 -samples 500
 ```
 ```console
- 100% |███████████████████████████████████████████████████████| (100/100, 71 it/s)        
-
+Mean Block Time: 6.243974s (500 samples)
 Estimated block height at Mon Aug 21 13:23:00 PDT 2023 is 11234156
 ```
 
@@ -19,9 +18,7 @@ Estimated block height at Mon Aug 21 13:23:00 PDT 2023 is 11234156
 go run main.go -height 11260923 -rpc https://main.rpc.agoric.net:443 -samples 1000
 ```
 ```console
- 100% |██████████████████████████████████████████████████████| (1000/1000, 71 it/s)         
-
-Average Block Time: 6.291125s (1000 samples)
+Mean Block Time: 6.291125s (1000 samples)
 Estimated time for height 11260923:
         Local: Mon Aug 21 06:01:08 PDT 2023
           UTC: Mon Aug 21 13:01:08 UTC 2023

--- a/estimator/estimator.go
+++ b/estimator/estimator.go
@@ -111,12 +111,12 @@ func (e *Estimator) getAvgBlockDurationNanos() (time.Duration, error) {
 		return 0, err
 	}
 	bar := progressbar.Default(e.Samples)
-	makeQuerier := func(sink []time.Time, i int64, blockToQuery int64, bar *progressbar.ProgressBar) func() {
+	makeQuerier := func(sink []time.Time, i int64, blockHeight int64, bar *progressbar.ProgressBar) func() {
 		return func() {
-			blockHeight, err := e.getBlockTime(blockToQuery)
+			blockTime, err := e.getBlockTime(blockHeight)
 			if err == nil {
 				mut.Lock()
-				sink[i] = blockHeight
+				sink[i] = blockTime
 				mut.Unlock()
 			}
 			bar.Add(1)

--- a/estimator/estimator.go
+++ b/estimator/estimator.go
@@ -102,16 +102,16 @@ func (e *Estimator) getBlockTime(height int64) (time.Time, error) {
 }
 
 func (e *Estimator) getAvgBlockDurationNanos() (time.Duration, error) {
-	wp := workerpool.New(int(e.Threads))
-	mut := sync.Mutex{}
-	resultSamples := make([]time.Time, e.Samples+1)
-
 	curHeight, err := e.getCurHeight()
 	if err != nil {
 		return 0, err
 	}
-	bar := progressbar.Default(e.Samples)
-	makeQuerier := func(sink []time.Time, i int64, blockHeight int64, bar *progressbar.ProgressBar) func() {
+
+	var statmodeDesc string
+	var avgDur time.Duration
+	wp := workerpool.New(int(e.Threads))
+	mut := sync.Mutex{}
+	makeQuerier := func(sink []time.Time, i int, blockHeight int64, bar *progressbar.ProgressBar) func() {
 		return func() {
 			blockTime, err := e.getBlockTime(blockHeight)
 			if err == nil {
@@ -119,38 +119,47 @@ func (e *Estimator) getAvgBlockDurationNanos() (time.Duration, error) {
 				sink[i] = blockTime
 				mut.Unlock()
 			}
-			bar.Add(1)
+			if bar != nil {
+				bar.Add(1)
+			}
 		}
-	}
-
-	for i := int64(0); i <= e.Samples; i++ {
-		wp.Submit(makeQuerier(resultSamples, i, curHeight-i, bar))
-	}
-	wp.StopWait()
-	bar.Finish()
-	fmt.Println("")
-
-	deltas := make([]time.Duration, e.Samples)
-	for i := 1; i < len(resultSamples); i++ {
-		diff := resultSamples[i-1].UnixNano() - resultSamples[i].UnixNano()
-		deltas[i-1] = time.Duration(diff)
 	}
 	switch e.Statmode {
 	case STATMODE_MEAN:
-		sumDur := time.Duration(0)
-		for i := 0; i < len(deltas); i++ {
-			sumDur += deltas[i]
+		// Estimate from just the two endpoints.
+		statmodeDesc = "Mean"
+		resultSamples := make([]time.Time, 2)
+		for i, height := range []int64{curHeight - e.Samples, curHeight} {
+			wp.Submit(makeQuerier(resultSamples, i, height, nil))
 		}
-		avgDur := time.Duration(sumDur.Nanoseconds() / int64(len(deltas)))
-		fmt.Printf("Mean Block Time: %fs (%d samples)\n", avgDur.Seconds(), e.Samples)
-		return avgDur, nil
+		wp.StopWait()
+		totalNanoseconds := resultSamples[1].UnixNano() - resultSamples[0].UnixNano()
+		avgDur = time.Duration(totalNanoseconds / e.Samples)
 	case STATMODE_MEDIAN:
-		medianBlockTime := time.Duration(median(deltas))
-		fmt.Printf("Median Block Time: %fs (%d samples)\n", medianBlockTime.Seconds(), e.Samples)
-		return medianBlockTime, nil
+		// Take the necessary samples, starting at current height and moving backwards.
+		statmodeDesc = "Median"
+		resultSamples := make([]time.Time, e.Samples+1)
+		bar := progressbar.Default(e.Samples)
+		for i := int64(0); i <= e.Samples; i++ {
+			wp.Submit(makeQuerier(resultSamples, int(i), curHeight-i, bar))
+		}
+		wp.StopWait()
+		bar.Finish()
+		fmt.Println("")
+
+		// Calculate deltas and take the median.
+		deltas := make([]time.Duration, e.Samples)
+		for i := 1; i < len(resultSamples); i++ {
+			diff := resultSamples[i-1].UnixNano() - resultSamples[i].UnixNano()
+			deltas[i-1] = time.Duration(diff)
+		}
+		avgDur = time.Duration(median(deltas))
 	default:
 		return 0, fmt.Errorf("invalid statmode")
 	}
+
+	fmt.Printf("%s Block Time: %fs (%d samples)\n", statmodeDesc, avgDur.Seconds(), e.Samples)
+	return avgDur, nil
 }
 
 func (e *Estimator) CalcBlock(date time.Time) (int64, error) {


### PR DESCRIPTION
There's no need to calculate N consecutive deltas just to sum them up anyway; the sum of deltas from i=1 to N of arr[i-1] - arr[i] is arr[0] - arr[N] so we can skip the middle.