### PR TITLE
feat: estimate time by offset

### DIFF
--- a/estimator/estimator.go
+++ b/estimator/estimator.go
@@ -195,3 +195,79 @@ func (e *Estimator) CalcDate(height int64) (time.Time, error) {
 
 	return time.Now().Add(gapTime), nil
 }
+
+func (e *Estimator) CalcDateWithOffset(height int64, offset time.Duration) (time.Time, error) {
+	curHeight, err := e.getCurHeight()
+	if err != nil {
+		return time.Time{}, err
+	}
+	if height <= curHeight {
+		return time.Time{}, fmt.Errorf("height to estimate must be greater than current height %d", curHeight)
+	}
+
+	curTime, err := e.getBlockTime(curHeight)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	bzHeight, err := e.findBlockHeightByTime(curHeight, curTime.Add(-offset))
+	if err != nil {
+		fmt.Println("err", err)
+		return time.Time{}, err
+	}
+
+	range_ := height - curHeight
+	if curHeight-bzHeight < range_ {
+		bzHeight = curHeight - range_
+	}
+
+	bzTime, err := e.getBlockTime(bzHeight)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	btHeight := bzHeight + range_
+	btTime, err := e.getBlockTime(btHeight)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	timeDelta := btTime.Sub(bzTime)
+	estimatedTime := curTime.Add(timeDelta)
+
+	return estimatedTime, nil
+}
+
+func (e *Estimator) findBlockHeightByTime(curHeight int64, targetTime time.Time) (int64, error) {
+	low, high := int64(1), curHeight
+	avgBlockTime, err := e.getAvgBlockDurationNanos()
+	if err != nil {
+		return 0, err
+	}
+
+	for low <= high {
+		mid := (low + high) / 2
+		midTime, err := e.getBlockTime(mid)
+		if err != nil {
+			return 0, err
+		}
+
+		if midTime.Before(targetTime) {
+			low = mid + 1
+		} else if midTime.After(targetTime) {
+			high = mid - 1
+		} else {
+			return mid, nil
+		}
+
+		if targetTime.Sub(midTime) > 0 {
+			estBlocks := int64(targetTime.Sub(midTime) / avgBlockTime)
+			low = mid + estBlocks/2
+		} else {
+			estBlocks := int64(midTime.Sub(targetTime) / avgBlockTime)
+			high = mid - estBlocks/2
+		}
+	}
+
+	return low, nil
+}

--- a/estimator/estimator.go
+++ b/estimator/estimator.go
@@ -245,6 +245,7 @@ func (e *Estimator) findBlockHeightByTime(curHeight int64, targetTime time.Time)
 		return 0, err
 	}
 
+	var result int64 = -1
 	for low <= high {
 		mid := (low + high) / 2
 		midTime, err := e.getBlockTime(mid)
@@ -254,20 +255,46 @@ func (e *Estimator) findBlockHeightByTime(curHeight int64, targetTime time.Time)
 
 		if midTime.Before(targetTime) {
 			low = mid + 1
-		} else if midTime.After(targetTime) {
-			high = mid - 1
 		} else {
-			return mid, nil
+			// This block is a candidate for the result
+			result = mid
+			high = mid - 1
 		}
 
 		if targetTime.Sub(midTime) > 0 {
 			estBlocks := int64(targetTime.Sub(midTime) / avgBlockTime)
-			low = mid + estBlocks/2
+			if estBlocks > 0 {
+				low = mid + (estBlocks+1)/2
+			} else {
+				low = mid + 1
+			}
 		} else {
 			estBlocks := int64(midTime.Sub(targetTime) / avgBlockTime)
-			high = mid - estBlocks/2
+			if estBlocks > 0 {
+				high = mid - (estBlocks+1)/2
+			} else {
+				high = mid - 1
+			}
 		}
 	}
 
-	return low, nil
+	if result == -1 {
+		return 0, fmt.Errorf("no block found with time >= target time")
+	}
+
+	for {
+		if result == 1 {
+			break
+		}
+		prevTime, err := e.getBlockTime(result - 1)
+		if err != nil {
+			return 0, err
+		}
+		if prevTime.Before(targetTime) {
+			break
+		}
+		result--
+	}
+
+	return result, nil
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 func run() (exitStatus int, err error) {
 	fHeight := flag.Int64("height", 0, "specific height to estimate the time of")
 	fDate := flag.String("date", "", "specific time to estimate height at, e.g. Mon Jan 2 15:04:05 MST 2006")
+	fOffset := flag.String("offset", "", "date/time offset for height estimation, e.g. 7d")
 	fSamples := flag.Int64("samples", 100, "count of samples to take")
 	fRpc := flag.String("rpc", "https://main.rpc.agoric.net:443", "the rpc endpoint to sample from")
 	fVotingPeriod := flag.Duration("votingPeriod", 24*3*time.Hour, "the voting period of the destination chain")
@@ -47,7 +49,16 @@ func run() (exitStatus int, err error) {
 
 	var timeRemaining time.Duration
 	if *fHeight > 0 {
-		estTime, err := esti.CalcDate(*fHeight)
+		var estTime time.Time
+		if *fOffset != "" {
+			offset, err := parseDuration(*fOffset)
+			if err != nil {
+				return 1, fmt.Errorf("invalid offset: %v", err)
+			}
+			estTime, err = esti.CalcDateWithOffset(*fHeight, offset)
+		} else {
+			estTime, err = esti.CalcDate(*fHeight)
+		}
 		if err != nil {
 			return 1, err
 		}
@@ -97,6 +108,19 @@ func run() (exitStatus int, err error) {
 	}
 
 	return 0, nil
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	if strings.HasSuffix(s, "d") {
+		dayStr := s[:len(s)-1]
+		days, err := strconv.ParseFloat(dayStr, 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(days * float64(24*time.Hour)), nil
+	}
+
+	return time.ParseDuration(s)
 }
 
 func main() {


### PR DESCRIPTION
### Description

Closes: https://github.com/Agoric/estimator/issues/5

This PR adds an `-offset` arg to the estimator to more accurately estimate the expected time of a future block

### Without offset

```
❯ go run main.go -height 17842500 -rpc https://main-a.rpc.agoric.net:443 -samples 1000
Mean Block Time: 14.825253s (1000 samples)
Estimated time for height 17842500:
        Local: Sat Jan 11 14:57:16 PKT 2025
          UTC: Sat Jan 11 09:57:16 UTC 2025
   Asia/Tokyo: Sat Jan 11 18:57:16 JST 2025
Australia/NSW: Sat Jan 11 20:57:16 AEDT 2025
Asia/Istanbul: Sat Jan 11 12:57:16 +03 2025
   US/Pacific: Sat Jan 11 01:57:16 PST 2025
   US/Eastern: Sat Jan 11 04:57:16 EST 2025
****** WARNING ******
Insufficient time for voting period: 70h5m55.450267553s
****** WARNING ******
```

### With offset

```
❯ go run main.go -height 17842500 -offset 7.2d  -rpc https://main-a.rpc.agoric.net:443 -samples 1000
Mean Block Time: 14.762233s (1000 samples)
Estimated time for height 17842500:
        Local: Fri Jan 10 19:59:43 PKT 2025
          UTC: Fri Jan 10 14:59:43 UTC 2025
   Asia/Tokyo: Fri Jan 10 23:59:43 JST 2025
Australia/NSW: Sat Jan 11 01:59:43 AEDT 2025
Asia/Istanbul: Fri Jan 10 17:59:43 +03 2025
   US/Pacific: Fri Jan 10 06:59:43 PST 2025
   US/Eastern: Fri Jan 10 09:59:43 EST 2025
****** WARNING ******
Insufficient time for voting period: 51h9m11.308282955s
****** WARNING ******
```

Since we were targeting Friday 10th 14 UTC, the latter seems more accurate than the former. Since I did not have any other data points, so this is the only verification I did. 